### PR TITLE
Fixes for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+
+
+# 2.0.0
+
+If you are managing the installer with this module (`manage_installer => true`) then this release is not compatible with the 1.x releases, please read the release notes and documentation carefully.
+
+* (break) Removed `source_path` option and replaced with `source_uri`
+* (break) The module no longer supports downloading from `puppet:///` locations, if you really need to do this then you will need to manage the file from outside of this module (eg: your profile) and specify `manage_installer => false`.  The module supports `http://`, `https://`, `ftp://`, `file://` and `s3://` uri's as supported by puppet-archive
+* Now uses `puppet/archive` instead of file resources for managing the installer 
+* Added systemd unit file for managing the smo service on systemd based platforms
+* New options for managing service
+* Module now cleans up the installer file after install
+* Various ordering/dependency bug fixes

--- a/README.md
+++ b/README.md
@@ -7,41 +7,104 @@ This module manages the SnapManager for Oracle package.
 
 ## Packaging
 
-The SMO package comes as a binary self-contained executable installer that supports a silent running mode.  The .bin file must already exist, or be downloaded from the Puppet server from a specified source.
+The SMO package comes as a binary self-contained executable installer that supports a silent running mode.  The .bin file must already exist, or be downloaded from a specified source URI (http://, file://, ftp://, s3://...).
 
-## Example
+# Example
 
 ```
     class { 'netapp_smo':
       version     => '3.4',
-      source_path => 'puppet:///binaries/smo',
+      source_uri  => 'http://content.mycorp.com/archives/netapp_smo'
     }
 ```
 
-## Parameters
+# Configuration
 
-`source_path`: 
-Path to find the installation binary (eg: puppet:///modules/smo)
+## Class: netapp_smo
 
-`version`: 
+### Parameters
+
+`source_uri`:
+Path to find the folder containing the installation binary (eg: puppet:///modules/smo).  The source URI should be the containing folder for `installer_filename`
+
+`version`: (optional)
 Version of SMO to install
 
-`manage_installer`: 
-True or false, whether to manage the installer binary, if set to false then the binary must exist on the system
+`manage_installer`: (optional, boolean)
+True or false, whether to manage the installer binary, if set to false then the binary must exist on the system. If `manage_installer` is true then a `source_uri` must be supplied.
 
-`installer_path`: 
-Path where the installer binary is to be found, if manage_installer is set to true then the module will create this folder and download the binary to it
+`installer_path`: (optional)
+Path where the installer binary is to be found, if manage_installer is set to true then the module will download the binary file here (it is deleted after install).  default: /tmp
 
-`system_type`: 
-The system type we are installing, default: linux
+`manage_installer_path`: (optional, boolean)
+Whether or not to try and manage/create the `installer_path`, default: false
 
-`system_arch`: 
-The system arch we are installing, default: x64
-
-`installer_filename`: 
+`installer_filename`: (optional)
 If version, arch and system_type are set then the installer filename will be determined automatically, but can be overridden here.  
+
+`manage_systemd`: (optional, boolean)
+Whether or not to manage the systemd unit file.  Defaults to `true` on RedHat 7 derivitives and `false` on others
+
+`manage_service`: (optional, boolean)
+Whether or not to try and manage the service
+
+`service_name`: (optional)
+Name of the service, default: netapp-smo
+
+`service_start`: (optional)
+Specify a custom start command for the service if `manage_service` is true, default: undef
+
+`service_stop`: (optional)
+Specify a custom stop command for the service if `manage_service` is true, default: undef
+
+`service_status`: (optional)
+Specify a custom status  command for the service if `manage_service` is true, default: undef
+
+`service_hasrestart`: (optional, boolean)
+Whether or not the service has a restart capability, default: undef
+
+`system_type`: (optional)
+The system type we are installing, used for autodetermining the `installer_filename`. default: linux
+
+`system_arch`: (optional)
+The system arch we are installing, used for autodetermining the `installer_filename`. default: x64
+
+`smo_root`: (optional)
+The location of the snapmanager binaries, defaults to `/opt/NetApp`, or `/opt/NTAPsmo` on Solaris
+
+`properties`: (optional, hash)
+A hash of `netapp_smo::property` types to configure. (see below)
+
+### Service
+
+If you are running on systemd it is advisable to use the systemd script provided by enabling `manage_systemd` to avoid problems with the SMO service sharing the same scope as Puppet and therefore stopped when Puppet is stopped. 
+
+If you are _not_ using systemd then you will probably need to specify how to start and stop the service, eg:
+
+```puppet
+class { 'netapp_smo':
+  ...
+  service_hasrestart => false,
+  service_start      => '/opt/NetApp/smo/bin/smo_server start',
+  service_stop       => '/opt/NetApp/smo/bin/smo_server stop',
+  service_status     => '/opt/NetApp/smo/bin/smo_server status',
+}
+```
+
+
+## Defined resource type: netapp_smo::property
+
+Configures properties in the `<smo_root>/smo/properties/smo.config` file
+
+The resource title corresponds to the name of the setting.
+
+### Parameters
+
+`ensure`: (optional)  Default to present
+`value`: Value to configure
+
 
 ## Author
 
-* Written and maintained by Craig Dunn <craig@craigdunn.org> @crayfisx
+* Written and maintained by Craig Dunn <craig@craigdunn.org> @crayfishx
 * Sponsered by Baloise Group [http://baloise.github.io](http://baloise.github.io)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The SMO package comes as a binary self-contained executable installer that suppo
 ### Parameters
 
 `source_uri`:
-Path to find the folder containing the installation binary (eg: puppet:///modules/smo).  The source URI should be the containing folder for `installer_filename`
+Path to find the folder containing the installation binary (eg: http://content.localdomain/netapp_smo).  The source URI should be the containing folder for `installer_filename`
 
 `version`: (optional)
 Version of SMO to install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,20 +45,18 @@
 # Copyright 2016 Craig Dunn
 #
 class netapp_smo (
-  $source_path        = undef,
-  $version            = undef,
-  $manage_installer   = true,
-  $installer_path     = '/opt/.smo_snapdrive',
-  $system_type        = 'linux',
-  $system_arch        = 'x64',
-  $installer_filename = undef,
-  $properties         = {}, 
-) {
-
-  $smo_root = $::osfamily ? {
-    'Solaris' => '/opt/NTAPsmo',
-    default   => '/opt/NetApp'
-  }
+  $source_uri            = undef,
+  $version               = undef,
+  $manage_installer      = $::netapp_smo::params::manage_installer,
+  $installer_path        = $::netapp_smo::params::installer_path,
+  $system_type           = $::netapp_smo::params::system_type,
+  $system_arch           = $::netapp_smo::params::system_arch,
+  $smo_root              = $::netapp_smo::params::smo_root,
+  $manage_systemd        = $::netapp_smo::params::manage_systemd,
+  $manage_installer_path = $::netapp_smo::params::manage_installer_path,
+  $installer_filename    = undef,
+  $properties            = {},
+) inherits netapp_smo::params {
 
 
   if $installer_filename {
@@ -72,29 +70,44 @@ class netapp_smo (
   }
 
   if $manage_installer {
-    file { $installer_path:
-      ensure => directory,
+    if ( !$source_uri ) {
+      fail('If manage_installer is true then a source_uri must be provided')
+    }
+
+    if $manage_installer_path {
+      file { $installer_path:
+        ensure => directory,
+      }
     }
   
+    archive { "${installer_path}/${filename}":
+      ensure          => present,
+      extract         => false,
+      cleanup         => false,
+      source          => "${source_uri}/${filename}",
+      creates         => "${smo_root}/smo",
+      before          => Exec['smo::install'],
+    }
+
+    ## Clean up the installer file once the install has completed.
     file { "${installer_path}/${filename}":
-      ensure => file,
-      mode   => '0755',
-      source => "${source_path}/${filename}",
-      before => Exec['smo::install'],
+      ensure  => absent,
+      backup  => false,
+      require => Exec['smo::install'],
     }
   }
 
   
   exec { 'smo::install':
     path    => '/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin',
-    command => "${installer_path}/${filename} -i silent",
+    command => "chmod 775 ${installer_path}/${filename}; ${installer_path}/${filename} -i silent",
     creates => "${smo_root}/smo",
   }
 
   create_resources('netapp_smo::property', $properties)
   Exec['smo::install'] -> Netapp_smo::Property <||>
 
-  if ( $::osfamily == 'Redhat' and $::operatingsystemmajrelease == '7' ) {
+  if $manage_systemd {
     systemd::unit_file { 'netapp-smo.service':
       content => template('netapp_smo/netapp-smo.service.erb'),
       before  => Service['netapp-smo']
@@ -102,9 +115,15 @@ class netapp_smo (
   }
 
 
-  service { 'netapp-smo':
-    ensure     => running,
-    require    => Exec['smo::install'],
-  } 
+  if $manage_service {
+    service { $service_name:
+      ensure     => running,
+      start      => $service_start,
+      stop       => $service_stop,
+      hasrestart => $service_hasrestart,
+      require    => Exec['smo::install'],
+    }
+    Netapp_smo::Property<||> -> Service[$service_name]
+  }
   
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,10 @@ class netapp_smo (
   $smo_root              = $::netapp_smo::params::smo_root,
   $manage_systemd        = $::netapp_smo::params::manage_systemd,
   $manage_installer_path = $::netapp_smo::params::manage_installer_path,
+  $service_status        = $::netapp_smo::params::service_status,
+  $service_start         = $::netapp_smo::params::service_start,
+  $service_stop          = $::netapp_smo::params::service_stop,
+  $service_hasrestart    = $::netapp_smo::params::service_hasrestart,
   $installer_filename    = undef,
   $properties            = {},
 ) inherits netapp_smo::params {
@@ -120,6 +124,7 @@ class netapp_smo (
       ensure     => running,
       start      => $service_start,
       stop       => $service_stop,
+      status     => $service_status,
       hasrestart => $service_hasrestart,
       require    => Exec['smo::install'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,9 @@ class netapp_smo (
   }
 
   
+  # We chmod the file first because we already have a file resource
+  # managing the installer to clean up after.
+  #
   exec { 'smo::install':
     path    => '/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin',
     command => "chmod 775 ${installer_path}/${filename}; ${installer_path}/${filename} -i silent",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class netapp_smo (
   $smo_root              = $::netapp_smo::params::smo_root,
   $manage_systemd        = $::netapp_smo::params::manage_systemd,
   $manage_installer_path = $::netapp_smo::params::manage_installer_path,
+  $manage_service        = $::netapp_smo::params::manage_service,
   $service_status        = $::netapp_smo::params::service_status,
   $service_start         = $::netapp_smo::params::service_start,
   $service_stop          = $::netapp_smo::params::service_stop,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class netapp_smo (
       hasrestart => $service_hasrestart,
       require    => Exec['smo::install'],
     }
-    Netapp_smo::Property<||> -> Service[$service_name]
+    Netapp_smo::Property<||> ~> Service[$service_name]
   }
   
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,29 @@
+class netapp_smo::params {
+
+  $manage_installer      = true
+  $installer_path        = '/tmp'
+  $system_type           = 'linux'
+  $system_arch           = 'x64'
+  $manage_installer_path = false
+  $manage_service        = true
+  $service_name          = 'netapp-smo'
+  $service_stop          = undef
+  $service_start         = undef
+  $service_hasrestart    = undef
+
+  $smo_root = $::osfamily ? {
+    'Solaris' => '/opt/NTAPsmo',
+    default   => '/opt/NetApp'
+  }
+
+  if ( $::osfamily == 'Redhat' and $::operatingsystemmajrelease == '7' ) {
+    $manage_systemd = true
+  } else {
+    $manage_systemd = false
+  }
+
+}
+
+
+
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class netapp_smo::params {
   $service_name          = 'netapp-smo'
   $service_stop          = undef
   $service_start         = undef
+  $service_status        = undef
   $service_hasrestart    = undef
 
   $smo_root = $::osfamily ? {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "crayfishx-netapp_smo",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Craig Dunn",
   "summary": "Manage SnapDrive for Oracle",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -17,15 +17,15 @@
     {
     "operatingsystem":"Solaris",
     "operatingsystemrelease":[ "10", "11" ]
-    },
-    {
-    "operatingsystem":"AIX"
     }
    ],
   "source": "https://github.com/crayfishx/puppet-netapp_smo",
   "project_page": "https://github.com/crayfishx/puppet-netapp_smo",
   "issues_url": "https://github.com/crayfishx/puppet-netapp_smo/issues",
   "dependencies": [
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.0.0 < 2.0.0"},
+    {"name":"camptocamp-systemd","version_requirement":">= 0.3.0 < 1.0.0"},
+    {"name":"puppet-archive","version_requirement":">= 0.5.0 < 2.0.0"},
   ]
 }
 

--- a/templates/netapp-smo.service.erb
+++ b/templates/netapp-smo.service.erb
@@ -1,7 +1,7 @@
 # Managed by Puppet
 #
 [Unit]
-Description=Snapchat for Oracle
+Description=Snapdrive Manager for Oracle
 
 
 [Service]

--- a/templates/netapp-smo.service.erb
+++ b/templates/netapp-smo.service.erb
@@ -7,6 +7,7 @@ Description=Snapchat for Oracle
 [Service]
 ExecStart=<%= @smo_root %>/smo/bin/smo_server start
 ExecStop=<%= @smo_root %>/smo/bin/smo_server stop
+Type=forking
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/netapp-smo.service.erb
+++ b/templates/netapp-smo.service.erb
@@ -1,0 +1,13 @@
+# Managed by Puppet
+#
+[Unit]
+Description=Snapchat for Oracle
+
+
+[Service]
+ExecStart=<%= @smo_root %>/smo/bin/smo_server start
+ExecStop=<%= @smo_root %>/smo/bin/smo_server stop
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
If you are managing the installer with this module (`manage_installer => true`) then this release is not compatible with the 1.x releases, please read the release notes and documentation carefully.
- (break) Removed `source_path` option and replaced with `source_uri`
- (break) The module no longer supports downloading from `puppet:///` locations, if you really need to do this then you will need to manage the file from outside of this module (eg: your profile) and specify `manage_installer => false`.  The module supports `http://`, `https://`, `ftp://`, `file://` and `s3://` uri's as supported by puppet-archive
- Now uses `puppet/archive` instead of file resources for managing the installer
- Added systemd unit file for managing the smo service on systemd based platforms
- New options for managing service
- Module now cleans up the installer file after install
- Various ordering/dependency bug fixes
