### PR TITLE
Added upgradable feature.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,12 @@
+---
+fixtures:
+  forge_modules:
+    archive:
+      repo: puppet/archive
+    inifile:
+      repo: puppetlabs/inifile
+    systemd:
+      repo: camptocamp/systemd
+  symlinks:
+    netapp_smo: "#{source_dir}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.swo
+Gemfile.lock
+pkg/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+script: "bundle exec rake test SPEC_OPTS='--format documentation'"
+rvm:
+  - 2.0
+
+
+env:
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.0.0"
+  - PUPPET_VERSION="~> 4.1.0"
+  - PUPPET_VERSION="~> 4.2.0"
+  - PUPPET_VERSION="~> 4.3.0"
+  - PUPPET_VERSION="~> 4.4.0"
+  - PUPPET_VERSION="~> 4.5.0"
+  - PUPPET_VERSION="~> 4.6.1"
+  - PUPPET_VERSION="~> 4.7.0"
+  - PUPPET_VERSION="~> 4.8.0"
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0
+
+Feature release.
+
+* Added the `upgradable` attribute to enable the module to track installed versions and attempt to upgrade an SMO installation.  By default this behaviour is disabled and can be enabled by setting `upgradable` to `true`.  See the README for more information on this option.
+
+
 ### 2.0.1
 
 Minor forge release, corrects the use of "SnapDrive for Oracle" to "SnapManager for Oracle"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 4.4.1']
+gem "puppet", puppetversion
+gem "puppetlabs_spec_helper"
+gem "rspec-puppet"
+gem "rspec"
+
+
+# JSON must be 1.x on Ruby 1.9
+if RUBY_VERSION < '2.0'
+  gem 'json', '~> 1.8'
+  gem 'json_pure', '~> 1.0'
+  gem 'rubocop', '0.41'
+end
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![Build Status](https://travis-ci.org/crayfishx/puppet-netapp_smo.svg?branch=feature%2Fversioned_installs)](https://travis-ci.org/crayfishx/puppet-netapp_smo)
+
 # netapp_smo
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The location of the snapmanager binaries, defaults to `/opt/NetApp`, or `/opt/NT
 A hash of `netapp_smo::property` types to configure. (see below)
 
 `upgradable`: (optional, boolean)
-This feature can only be used when `manage_installer` is true and a `version` attribute is supplied.  It causes the module to attempt to keep track of installed versions in `${smo_root}/.puppet/`  allowing you to upgrade SMO by changing the version.  If upgradable is set to `true` and the target version does not exist in `.puppet/` then the module will stop the SMO service and attempt to download and run the installer.  By default, this feature is disabled.  A future major release of this module will enable this by default.
+This feature can only be used when `manage_installer` is true and a `version` attribute is supplied.  It causes the module to attempt to keep track of installed versions in `${smo_root}/smo/.puppet/`  allowing you to upgrade SMO by changing the version.  If upgradable is set to `true` and the target version does not exist in `.puppet/` then the module will stop the SMO service and attempt to download and run the installer.  By default, this feature is disabled.  A future major release of this module will enable this by default.
 
 ### Service
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The location of the snapmanager binaries, defaults to `/opt/NetApp`, or `/opt/NT
 `properties`: (optional, hash)
 A hash of `netapp_smo::property` types to configure. (see below)
 
+`upgradable`: (optional, boolean)
+This feature can only be used when `manage_installer` is true and a `version` attribute is supplied.  It causes the module to attempt to keep track of installed versions in `${smo_root}/.puppet/`  allowing you to upgrade SMO by changing the version.  If upgradable is set to `true` and the target version does not exist in `.puppet/` then the module will stop the SMO service and attempt to download and run the installer.  By default, this feature is disabled.  A future major release of this module will enable this by default.
+
 ### Service
 
 If you are running on systemd it is advisable to use the systemd script provided by enabling `manage_systemd` to avoid problems with the SMO service sharing the same scope as Puppet and therefore stopped when Puppet is stopped. 

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,5 @@ task :validate do
     sh "erb -P -x -T '-' #{template} | ruby -c"
   end
 end
+
+task :test =>  [ :validate, :spec ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,20 @@ class netapp_smo (
       }
       $check_installed = "${smo_root}/.puppet/version-${version}"
 
+      # If we are managing upgradable versions and the target version does
+      # not exist then we should stop the service, we must do this with an
+      # exec
+      $stop_cmd = $::manage_systemd ? {
+        true    => "systemctl stop ${service_name}",
+        default => "service ${service_name} stop"
+      }
+      exec { 'netapp_smo::service_stop':
+        path    => '/sbin:/bin:/usr/sbin:/usr/bin',
+        command => $stop_cmd,
+        creates => "${smo_root}/.puppet/version-${version}",
+        before  => Exec['smo::install'],
+      }
+
     } else {
       $check_installed = "${smo_root}/smo"
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,22 +91,22 @@ class netapp_smo (
         fail("Must specify a version number in order to use upgradable feature")
       }
 
-      file { "${smo_root}/.puppet":
+      file { "${smo_root}/smo/.puppet":
         ensure  => directory,
         require => Exec['smo::install'],
       }
 
-      file { "${smo_root}/.puppet/version-${version}":
+      file { "${smo_root}/smo/.puppet/version-${version}":
         ensure  => file,
         content => "This file is needed by Puppet, no not remove",
         require => Exec['smo::install'],
       }
-      $check_installed = "${smo_root}/.puppet/version-${version}"
+      $check_installed = "${smo_root}/smo/.puppet/version-${version}"
 
       # If we are managing upgradable versions and the target version does
       # not exist then we should stop the service, we must do this with an
       # exec
-      $stop_cmd = $::manage_systemd ? {
+      $stop_cmd = $manage_systemd ? {
         true    => "systemctl stop ${service_name}",
         default => "service ${service_name} stop"
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ class netapp_smo (
   $service_start         = $::netapp_smo::params::service_start,
   $service_stop          = $::netapp_smo::params::service_stop,
   $service_hasrestart    = $::netapp_smo::params::service_hasrestart,
-  $track_versions        = $::netapp_smo::params::track_versions,
+  $upgradable            = $::netapp_smo::params::upgradable,
   $installer_filename    = undef,
   $properties            = {},
 ) inherits netapp_smo::params {
@@ -86,9 +86,9 @@ class netapp_smo (
       }
     }
 
-    if $track_versions {
+    if $upgradable {
       if (!$version) {
-        fail("Must specify a version number in order to use track_versions feature")
+        fail("Must specify a version number in order to use upgradable feature")
       }
 
       file { "${smo_root}/.puppet":
@@ -137,6 +137,8 @@ class netapp_smo (
       backup  => false,
       require => Exec['smo::install'],
     }
+  } else {
+    $check_installed = "${smo_root}/smo"
   }
 
   

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,10 +101,10 @@ class netapp_smo (
         content => "This file is needed by Puppet, no not remove",
         require => Exec['smo::install'],
       }
-      $archive_creates = "${smo_root}/.puppet/version-${version}"
+      $check_installed = "${smo_root}/.puppet/version-${version}"
 
     } else {
-      $archive_creates = "${smo_root}/smo"
+      $check_installed = "${smo_root}/smo"
     }
 
   
@@ -113,7 +113,7 @@ class netapp_smo (
       extract         => false,
       cleanup         => false,
       source          => "${source_uri}/${filename}",
-      creates         => $archive_creates,
+      creates         => $check_installed,
       before          => Exec['smo::install'],
     }
 
@@ -132,7 +132,7 @@ class netapp_smo (
   exec { 'smo::install':
     path    => '/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin',
     command => "chmod 775 ${installer_path}/${filename}; ${installer_path}/${filename} -i silent",
-    creates => "${smo_root}/smo",
+    creates => $check_installed,
   }
 
   create_resources('netapp_smo::property', $properties)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class netapp_smo::params {
   $service_start         = undef
   $service_status        = undef
   $service_hasrestart    = undef
+  $track_versions        = false
 
   $smo_root = $::osfamily ? {
     'Solaris' => '/opt/NTAPsmo',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class netapp_smo::params {
   $service_start         = undef
   $service_status        = undef
   $service_hasrestart    = undef
-  $track_versions        = false
+  $upgradable            = false
 
   $smo_root = $::osfamily ? {
     'Solaris' => '/opt/NTAPsmo',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,185 @@
 require 'spec_helper'
-describe 'smo' do
+describe 'netapp_smo' do
 
-  context 'with defaults for all parameters' do
-    it { should contain_class('smo') }
+  let(:facts) {{ 
+    :osfamily => "RedHat",
+    :operatingsystemmajrelease => "7",
+    :path => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin'
+  }}
+
+  context 'when supplying a version' do
+    let(:params) {{
+      :version => '3.4.1',
+      :source_uri => 'http://content/path'
+    }}
+
+    it { is_expected.to contain_class('netapp_smo') }
+
+    it do
+      is_expected.to contain_archive("/tmp/netapp.smo.linux-x64-3.4.1.bin").with(
+        :extract => false,
+        :cleanup => false,
+        :source  => "http://content/path/netapp.smo.linux-x64-3.4.1.bin",
+        :creates => "/opt/NetApp/smo"
+      ).that_comes_before('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_file("/tmp/netapp.smo.linux-x64-3.4.1.bin").with(
+        :ensure => :absent,
+        :backup => false
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_exec('smo::install').with(
+        :command => "chmod 775 /tmp/netapp.smo.linux-x64-3.4.1.bin; /tmp/netapp.smo.linux-x64-3.4.1.bin -i silent",
+        :creates => "/opt/NetApp/smo"
+      )
+    end
+
+    it do
+      is_expected.to contain_service('netapp-smo').with(
+        :ensure => :running
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_systemd__unit_file('netapp-smo.service').that_comes_before('Service[netapp-smo]')
+    end
+        
   end
+
+  context 'when supplying a filename' do
+    let(:params) {{
+      :installer_filename => 'netapp.smo-installer.bin',
+      :source_uri => 'http://content/path'
+    }}
+
+    it do
+      is_expected.to contain_archive("/tmp/netapp.smo-installer.bin").with(
+        :extract => false,
+        :cleanup => false,
+        :source  => "http://content/path/netapp.smo-installer.bin",
+        :creates => "/opt/NetApp/smo"
+      ).that_comes_before('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_file("/tmp/netapp.smo-installer.bin").with(
+        :ensure => :absent,
+        :backup => false
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_exec('smo::install').with(
+        :command => "chmod 775 /tmp/netapp.smo-installer.bin; /tmp/netapp.smo-installer.bin -i silent",
+        :creates => "/opt/NetApp/smo"
+      )
+    end
+  end
+
+  context "when neither version or filename are supplied" do
+    let(:params) {{ :source_uri => 'http://content/path' }}
+    it do
+      is_expected.to raise_error(/If version is not provided, a filename must be given/)
+    end
+  end
+
+  context "upgradable" do
+    let(:params) {{
+      :version => '3.4.1',
+      :source_uri => 'http://content/path',
+      :upgradable => true,
+    }}
+
+    it do
+      is_expected.to contain_file('/opt/NetApp/smo/.puppet').with(
+        :ensure => :directory
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_file('/opt/NetApp/smo/.puppet/version-3.4.1').with(
+        :ensure => :file,
+        :content => /This file is needed by Puppet/,
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_exec('netapp_smo::service_stop').with(
+        :command => 'systemctl stop netapp-smo'
+      ).that_comes_before('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_archive("/tmp/netapp.smo.linux-x64-3.4.1.bin").with(
+        :creates => "/opt/NetApp/smo/.puppet/version-3.4.1"
+      )
+    end
+
+    it do
+      is_expected.to contain_exec('smo::install').with(
+        :creates => "/opt/NetApp/smo/.puppet/version-3.4.1"
+      )
+    end
+  end
+
+  context "upgradable without version" do
+    let(:params) {{
+      :source_uri => 'http://content/path',
+      :installer_filename   => 'netapp-installer.bin',
+      :upgradable => true,
+    }}
+
+    it do
+      is_expected.to raise_error(/Must specify a version/)
+    end
+
+  end
+
+  context 'on Solaris' do
+    let(:facts) {{ 
+      :osfamily => "Solaris",
+      :operatingsystemmajrelease => "11",
+      :path => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin'
+    }}
+    let(:params) {{
+      :version => '3.4.1',
+      :system_type => 'solaris',
+      :source_uri => 'http://content/path'
+    }}
+
+    it do
+      is_expected.to contain_archive("/tmp/netapp.smo.solaris-x64-3.4.1.bin").with(
+        :creates => "/opt/NTAPsmo/smo"
+      )
+    end
+
+    it do
+      is_expected.to contain_file("/tmp/netapp.smo.solaris-x64-3.4.1.bin").with(
+        :ensure => :absent,
+        :backup => false
+      ).that_requires('Exec[smo::install]')
+    end
+
+    it do
+      is_expected.to contain_exec('smo::install').with(
+        :command => "chmod 775 /tmp/netapp.smo.solaris-x64-3.4.1.bin; /tmp/netapp.smo.solaris-x64-3.4.1.bin -i silent",
+        :creates => "/opt/NTAPsmo/smo"
+      )
+    end
+
+    it do
+      is_expected.not_to contain_systemd__unit_file('netapp-smo.service')
+    end
+
+    it do
+      is_expected.to contain_service('netapp-smo').with(
+        :ensure => :running
+      ).that_requires('Exec[smo::install]')
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,1 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, 'lib')
-
-require 'mocha'
-require 'puppet'
-require 'rspec'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
-end
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION

The current implementation does not allow you to upgrade SMO, if you change the version then nothing takes effect.  In order to make this work the module creates a .puppet directory under the SMO installation path in order to track previously installed versions.  This feature is disabled by default and enabled by setting `upgradable` to true.

