### PR TITLE
fixed invalid creates attribute for service stop exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class netapp_smo (
       exec { 'netapp_smo::service_stop':
         path    => '/sbin:/bin:/usr/sbin:/usr/bin',
         command => $stop_cmd,
-        creates => "${smo_root}/.puppet/version-${version}",
+        creates => "${smo_root}/smo/.puppet/version-${version}",
         before  => Exec['smo::install'],
       }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -109,7 +109,8 @@ describe 'netapp_smo' do
 
     it do
       is_expected.to contain_exec('netapp_smo::service_stop').with(
-        :command => 'systemctl stop netapp-smo'
+        :command => 'systemctl stop netapp-smo',
+        :creates => '/opt/NetApp/smo/.puppet/version-3.4.1',
       ).that_comes_before('Exec[smo::install]')
     end
 


### PR DESCRIPTION

This fix stops the service being stopped and started on every puppet run when running with `upgradable` set to true.